### PR TITLE
Update README.md

### DIFF
--- a/10-Terraform-Modules/10-01-Terraform-Modules-Basics/README.md
+++ b/10-Terraform-Modules/10-01-Terraform-Modules-Basics/README.md
@@ -97,9 +97,12 @@ http://<Public-IP-VM2>
 # List Resources from State
 terraform state list
 
-# Taint a Resource
+# Taint a Resource - Single instance Scenario
 terraform taint <RESOURCE-NAME>
-terraform taint module.ec2_cluster.aws_instance.this[0]
+terraform taint 'module.ec2_cluster.aws_instance.this[0]'
+
+# List a resource using multi-resource scenario
+terraform taint 'module.ec2_instance["1"].aws_instance.this[0]'
 
 # Terraform Plan
 terraform plan


### PR DESCRIPTION
$ terraform state show 'module.foo.packet_device.worker'
$ terraform state show 'module.ec2_instance["1"].aws_instance.this[0]'

Quotes required to refer to the right resource, when managing multiple resources. 